### PR TITLE
Fix pH calibration notebook

### DIFF
--- a/examples/pH_calibration/ph_calibration_utils.py
+++ b/examples/pH_calibration/ph_calibration_utils.py
@@ -78,7 +78,7 @@ def define_pH_adjustment_protocol_primitives(
         description="Determine if pH meets target pH",
     )
 
-    def at_target_compute_output(inputs, parameter):
+    def at_target_compute_output(inputs, parameter, sample_format):
         # X% weight/volume (g/mL) = (total_volume / 100) * X
         # return total_volume * percentage/100
         for input in inputs:
@@ -108,7 +108,7 @@ def define_pH_adjustment_protocol_primitives(
         description="Calculate NaOH Addition",
     )
 
-    def calculate_naoh_addition_output(inputs, parameter):
+    def calculate_naoh_addition_output(inputs, parameter, sample_format):
         # X% weight/volume (g/mL) = (total_volume / 100) * X
         # return total_volume * percentage/100
         # for input in inputs:
@@ -161,7 +161,7 @@ def wrap_with_error_message(protocol, library, primitive, **kwargs):
                 description=f"Extends {primitive} with an error output pin",
             )
 
-    def wrapped_primitive_compute_output(inputs, parameter):
+    def wrapped_primitive_compute_output(inputs, parameter, sample_format):
         return uml.literal(None)
     wrapped_primitive.compute_output = (
         wrapped_primitive_compute_output
@@ -227,7 +227,7 @@ def define_pH_calibration_protocol_primitives(
         description="Decide whether to calibrate pH meter.",
     )
 
-    def pH_meter_calibrated_compute_output(inputs, parameter):
+    def pH_meter_calibrated_compute_output(inputs, parameter, sample_format):
         return uml.literal(True)
     pH_meter_calibrated_primitive.compute_output = (
         pH_meter_calibrated_compute_output
@@ -265,7 +265,7 @@ def define_pH_calibration_protocol_primitives(
         "CleanElectrode",
         description="Clean the pH meter electrode",
     )
-    def clean_electrode_primitive_compute_output(inputs, parameter):
+    def clean_electrode_primitive_compute_output(inputs, parameter, sample_format):
         return None
     clean_electrode_primitive.compute_output = (
         clean_electrode_primitive_compute_output
@@ -294,7 +294,7 @@ def define_setup_protocol_primitives(
         outputs=[{"name": "volume", "type": tyto.OM.milliliter}],
         description="Decide whether to calibrate pH meter.",
     )
-    def calculate_volume_compute_output(inputs, parameter):
+    def calculate_volume_compute_output(inputs, parameter, sample_format):
         # X% weight/volume (g/mL) = (total_volume / 100) * X
         # return total_volume * percentage/100
         for input in inputs:

--- a/labop/execution_engine_utils.py
+++ b/labop/execution_engine_utils.py
@@ -890,7 +890,7 @@ def activity_parameter_node_next_tokens_callback(
                 labop.ActivityEdgeFlow(
                     edge=return_edge,
                     token_source=source,
-                    value=source.get_value(edge=return_edge)
+                    value=source.get_value(return_edge, node_outputs, sample_format)
                     #uml.literal(source.incoming_flows[0].lookup().value)
                     )
             ]


### PR DESCRIPTION
The `compute_output` handlers for the pH calibration primitives were incompatible with recent changes in other `compute_output` handlers.  This caused the pH calibration notebook to break.  This fixes that.