### PR TITLE
Removed submodule for container-ontology

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "labop-check"]
-	path = labop-check
-	url = https://github.com/Bioprotocols/labop-check.git
-[submodule "container-ontology"]
-	path = container-ontology
-	url = https://github.com/rpgoldman/container-ontology

--- a/README.md
+++ b/README.md
@@ -9,17 +9,6 @@ The LabOP package is available by PyPI:
 pip3 install labop
 ```
 
-The LabOP repo also includes git submodules containing the optional utility `labop-check` for checking consistency of protocol representations and a demo version of the `container-ontology` which provides standardized descriptions for laboratory containers.  These are currently not available as packages.  If you wish to use these you will have to clone the LabOP repo and install each of these separately:
-
-```
-git clone https://github.com/Bioprotocols/labop
-pip3 install .
-cd labop/labop-check
-pip3 install .
-cd ../container-ontology
-pip3 install .
-```
-
 LabOP visualizations currently depend on the `graphviz` application. To install graphviz, run (per https://github.com/ts-graphviz/setup-graphviz):
 * Mac: `brew install graphviz`
 * Linux: `apt-get install graphviz libgraphviz-dev pkg-config`


### PR DESCRIPTION
The container-ontology dependency is handled by pip install, so its not needed as a submodule.